### PR TITLE
Fixed schemas, adjusted planet count.

### DIFF
--- a/backend/controllers/universe/controller.ts
+++ b/backend/controllers/universe/controller.ts
@@ -27,7 +27,7 @@ export async function getUniverseController(req: Request, res: Response): Promis
 
   const solarSystemRadius = galaxy.radius / 15;
   const solarSystemStars = solarSystemRadius * density;
-  const solarSystemPromptArgs: PromptFnArgs = {radiusMin: solarSystemRadius * .95, radiusMax: solarSystemRadius * 1.05, bodiesMin: solarSystemStars * 0.95, bodiesMax: solarSystemStars * 1.05};
+  const solarSystemPromptArgs: PromptFnArgs = {radiusMin: solarSystemRadius * .95, radiusMax: solarSystemRadius * 1.05, bodiesMin: 5, bodiesMax: 12};
   const solarSystem = await promptWithSchema(solarSystemPrompt(solarSystemPromptArgs), SolarSystemSchema);
   if (solarSystem === undefined) {
     res.json({message: "There was an error generating a solar system."});

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -2,25 +2,17 @@ import { z, ZodRawShape } from "zod";
 
 export const UniverseSchema = z.object({
   name: z.string(),
-  id: z.string(),
   starCount: z.number(),
   radius: z.number(),
 });
 
 export const GalaxySchema = z.object({
   name: z.string(),
-  id: z.string(),
   starCount: z.number(),
   radius: z.number(),
 });
 
 export const SolarSystemSchema = z.object({
   name: z.string(),
-  id: z.string(),
   planetCount: z.number(),
-});
-
-export const PlanetSchema = z.object({
-  name: z.string(),
-  id: z.string(),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 041ce9330fe67c7f1f082bce88f4a7190f660879  | 
|--------|--------|

### Summary:
Adjusted planet count range in solar system generation and removed `id` fields from schemas.

**Key points**:
- Updated `getUniverseController` in `backend/controllers/universe/controller.ts` to set `bodiesMin` to 5 and `bodiesMax` to 12 for solar systems.
- Removed `id` field from `UniverseSchema`, `GalaxySchema`, and `SolarSystemSchema` in `backend/src/schemas.ts`.
- Adjusted solar system generation to have a fixed range of 5 to 12 planets.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->